### PR TITLE
Add `NEUTRAL` in weather list

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,20 +1,21 @@
 local display = true
 
 Weathers = {
-    "EXTRASUNNY" ,
-    "CLEAR" ,
-    "CLEARING" ,
-    "OVERCAST" ,
-    "SMOG" ,
-    "FOGGY" ,
-    "CLOUDS" ,
-    "RAIN" ,
-    "THUNDER" ,
-    "SNOW" ,
-    "BLIZZARD" ,
-    "SNOWLIGHT" ,
-    "XMAS" ,
-    "HALLOWEEN" ,
+    "EXTRASUNNY",
+    "CLEAR",
+    "CLEARING",
+    "OVERCAST",
+    "SMOG",
+    "FOGGY",
+    "CLOUDS",
+    "RAIN",
+    "THUNDER",
+    "SNOW",
+    "BLIZZARD",
+    "SNOWLIGHT",
+    "XMAS",
+    "HALLOWEEN",
+    "NEUTRAL",
 }
 
 Times = {


### PR DESCRIPTION
Added a missing weather type (neutral) in weathers list.

Source of weather types: https://docs.fivem.net/natives/?_0x29B487C359E19889